### PR TITLE
Update README.md with deployment links and added DEPLOYMENTS.md file

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -1,0 +1,36 @@
+This document details the deployment history of the `reg-pilot-api` and `vlei-verifier` services across the test and dev domains. It includes the keripy version and the last commit associated with deployment dates.
+
+## Deployment Log
+
+### 1. reg-pilot-api
+
+#### a. dev domain
+
+| #  | Date       | keripy version | Last Commit Hash | 
+|----|------------|----------------|------------------|
+| 1  | 2024-08-09 | 1.1.17         | [b38f8e4]        | 
+| 2  | 2024-08-29 | 1.2.0-dev13    | [aceccd5]        | 
+
+
+#### b. test domain
+
+| #  | Date       | keripy version | Last Commit Hash | 
+|----|------------|----------------|------------------|
+| 1  | 2024-08-09 | 1.1.17         | [b38f8e4]        | 
+
+
+### 2. vlei-verifier
+
+#### a. dev domain
+
+| #  | Date       | keripy version | Last Commit Hash | 
+|----|------------|----------------|------------------|
+| 1  | 2024-08-09 | 1.1.17         | [c28678a]        | 
+| 2  | 2024-08-29 | 1.2.0-dev13    | [a10baa8]        |
+
+
+#### b. test domain
+
+| #  | Date       | keripy version | Last Commit Hash | 
+|----|------------|----------------|------------------|
+| 1  | 2024-08-09  | 1.1.17        | [c28678a]        | 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Reg-pilot related information, issues, discussions, and more.
 ## Demo test instances
 * Demo keria instance url = ```https://keria-dev.rootsid.cloud/admin``` and boot url = ```https://keria-dev.rootsid.cloud```
 * Demo signify passcode = ```Ap31Xt-FGcNXpkxmBYMQn```
-* [Demo reg-webapp](https://reg-pilot-webapp-test.rootsid.cloud/) currently requires the [signify-browser-extension](https://github.com/WebOfTrust/signify-browser-extension) to be installed
-* [Demo reg-pilot-api](https://reg-api-test.rootsid.cloud/doc#/) - [ping it](https://reg-api-test.rootsid.cloud/ping)
+* Demo reg-webapp: [Test](https://reg-pilot-webapp-test.rootsid.cloud/) | [Dev](https://reg-pilot-webapp-dev.rootsid.cloud/)  currently requires the [signify-browser-extension](https://github.com/WebOfTrust/signify-browser-extension) to be installed
+* Demo reg-pilot-api:
+  [Test](https://reg-api-test.rootsid.cloud/docs/) - [ping it](https://reg-api-test.rootsid.cloud/ping) | [Dev](https://reg-api-dev.rootsid.cloud/docs/) - [ping it](https://reg-api-dev.rootsid.cloud/ping)
 * Demo witness urls: ```"https://witness-dev01.rootsid.cloud", 
                     "https://witness-dev02.rootsid.cloud",
                     "https://witness-dev03.rootsid.cloud"```
@@ -26,3 +27,6 @@ At a high-level idea, each file has a digest computed on it and the file and sig
 ### Test reports
 You can find a variety of test report files here.
 * [Demo reports](https://github.com/GLEIF-IT/vlei-verifier/tree/main/tests/data/report)
+
+## Deployment Logs
+For deployment history and version details of the reg-pilot-api and vlei-verifier services, see the [`DEPLOYMENTS.md`](./DEPLOYMENTS.md) file.


### PR DESCRIPTION
Updated the README.md file to include separate URLs for the reg-webapp and reg-pilot-api services in both test and dev domains. Additionally, added a new DEPLOYMENTS.md file that logs deployment history for the reg-pilot-api and vlei-verifier services, including keripy version and last commit details.