### PR TITLE
Removed watch: true from jest config to get rid of warning thrown in tests.

### DIFF
--- a/signify-ts-test/jest.config.ts
+++ b/signify-ts-test/jest.config.ts
@@ -4,7 +4,6 @@ const config: Config = {
   preset: "ts-jest",
   testMatch: ["<rootDir>/test/*.test.ts"],
   projects: ["<rootDir>/test"],
-  watch: false,
 };
 
 export default config;


### PR DESCRIPTION
watch: true does not exist as a property in jest Config.  It should fix an error that was thrown when running tests.