### PR TITLE
Update jest.config.ts to remove warning.

### DIFF
--- a/signify-ts-test/test/jest.config.ts
+++ b/signify-ts-test/test/jest.config.ts
@@ -2,7 +2,7 @@ import { Config } from "jest";
 
 const config: Config = {
   preset: "ts-jest",
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"]
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 };
 
 export default config;

--- a/signify-ts-test/test/jest.config.ts
+++ b/signify-ts-test/test/jest.config.ts
@@ -2,8 +2,7 @@ import { Config } from "jest";
 
 const config: Config = {
   preset: "ts-jest",
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
-  watch: false,
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"]
 };
 
 export default config;


### PR DESCRIPTION
jest.config.ts throws a warning when 'watch: false` is set (as it doesn't exist as a value in this config schema).  Removed to get rid of the warning.