### PR TITLE
Add report cleanup to test workflow and update load-test doc

### DIFF
--- a/signify-ts-test/LOAD.md
+++ b/signify-ts-test/LOAD.md
@@ -74,6 +74,7 @@ After completing the API/Verifier tests, the corresponding downloaded report fil
 ```
 Cleaning up report files for Bank_3...
 ```
+
 ```
  PASS  test/run-bank-reports-cleanup.test.ts
   ✓ bank-reports-cleanup (65 ms)
@@ -199,6 +200,7 @@ After completing the API/Verifier test, the corresponding downloaded report file
 ```
 Cleaning up report files for Bank_10...
 ```
+
 ```
  PASS  test/run-bank-reports-cleanup.test.ts
   ✓ bank-reports-cleanup (64 ms)

--- a/signify-ts-test/LOAD.md
+++ b/signify-ts-test/LOAD.md
@@ -67,6 +67,23 @@ Tests:       1 passed, 1 total
 Snapshots:   0 total
 Time:        4.424 s, estimated 5 s
 Ran all test suites matching /.\/run-workflow-bank-api.test.ts/i.
+```
+
+After completing the API/Verifier tests, the corresponding downloaded report files are cleaned up:
+
+```
+Cleaning up report files for Bank_3...
+```
+```
+ PASS  test/run-bank-reports-cleanup.test.ts
+  ✓ bank-reports-cleanup (65 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        0.858 s, estimated 2 s
+...
+Report files for Bank_3 cleaned up successfully.
 Test successful for Bank_3.
 ```
 
@@ -175,7 +192,24 @@ Tests:       1 passed, 1 total
 Snapshots:   0 total
 Time:        8.579 s, estimated 9 s
 Ran all test suites matching /.\/run-workflow-bank-api.test.ts/i.
-Test successful for Bank_1.
+```
+
+After completing the API/Verifier test, the corresponding downloaded report files are cleaned up:
+
+```
+Cleaning up report files for Bank_10...
+```
+```
+ PASS  test/run-bank-reports-cleanup.test.ts
+  ✓ bank-reports-cleanup (64 ms)
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        1.945 s
+...
+Report files for Bank_10 cleaned up successfully.
+Test successful for Bank_10.
 ```
 
 Since this test involves interacting with the target API remotely, no local services are started. However, KERIA agents are initialized for each bank to interact with the target API and facilitate the test workflow.

--- a/signify-ts-test/test-load.sh
+++ b/signify-ts-test/test-load.sh
@@ -103,7 +103,7 @@ parse_args() {
     }
 
 check_available_banks() {
-    local TOTAL_AVAILABLE_BANKS=10
+    local TOTAL_AVAILABLE_BANKS=30
 
     if [[ "$BANK_COUNT" -gt "$TOTAL_AVAILABLE_BANKS" ]]; then
         echo "WARNING: You have selected more banks ($BANK_COUNT) than available ($TOTAL_AVAILABLE_BANKS)."
@@ -143,7 +143,7 @@ stop_keria() {
 # Run Bank Test Workflow (Local or Remote)
 run_bank_test_workflow() {
     echo "Downloading reports for $BANK_NAME..."
-    TEST_ENVIRONMENT="docker" ./test-workflow-banks.sh --build --reports-download
+    ./test-workflow-banks.sh --build --reports-download
     check_status "Downloading reports for $BANK_NAME"
 
     if [[ "$MODE" == "local" ]]; then
@@ -154,6 +154,11 @@ run_bank_test_workflow() {
         TEST_ENVIRONMENT="bank_test" REG_PILOT_API="$REG_PILOT_API" ./test-workflow-banks.sh --verify-proxy
     fi
     check_status "Test workflow for $BANK_NAME"
+
+    echo "Cleaning up report files for $BANK_NAME..."
+    ./test-workflow-banks.sh --reports-cleanup
+    check_status "Cleaning up report files for $BANK_NAME"
+    echo "Report files for $BANK_NAME cleaned up successfully."
 }
 
 # Load Test for Banks

--- a/signify-ts-test/test-workflow-banks.sh
+++ b/signify-ts-test/test-workflow-banks.sh
@@ -63,8 +63,8 @@ while [[ $# -gt 0 ]]; do
             ;;
         --reports-cleanup)
             npx jest ./run-bank-reports-cleanup.test.ts --runInBand --forceExit
-            download_exit_code=$?  
-                if [[ $download_exit_code -ne 0 ]]; then
+            cleanup_exit_code=$?  
+                if [[ $cleanup_exit_code -ne 0 ]]; then
                 exit 1  
                 fi
             shift # past argument


### PR DESCRIPTION
- Added report files cleanup step in the test workflow to delete reports after each bank's test execution.
- Updated load.md to include details of the cleanup process for local and remote load tests.